### PR TITLE
Make the access to RN API via variable js/ReactNative

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject natal-shell "0.2.1"
+(defproject natal-shell "0.3.0-SNAPSHOT"
   :description "A thin ClojureScript wrapper around the React Native API"
   :url "https://github.com/dmotz/natal-shell/"
   :license {:name "The MIT License (MIT)"

--- a/scripts/scraper.clj
+++ b/scripts/scraper.clj
@@ -63,20 +63,20 @@
 (defn method-macro [react-ns js-name]
   `(defmacro ~(symbol (to-kebab js-name)) [& ~'args]
      `(~'~(symbol (str "." js-name))
-       ~'~(symbol (str "js/React." react-ns))
+       ~'~(symbol (str "js/ReactNative." react-ns))
        ~@~'args)))
 
 
 (defn constructor-macro [react-ns js-name]
   `(defmacro ~(symbol (to-kebab js-name)) [& ~'args]
-     `(~'~(symbol (str "js/React." react-ns "." js-name "."))
+     `(~'~(symbol (str "js/ReactNative." react-ns "." js-name "."))
         ~@~'args)))
 
 
 (defn property-macro [react-ns js-name]
   `(defmacro ~(symbol (to-kebab js-name)) []
      `(~'~(symbol (str ".-" js-name))
-        ~'~(symbol (str "js/React." react-ns)))))
+        ~'~(symbol (str "js/ReactNative." react-ns)))))
 
 
 (defn make-writer [path]

--- a/src/natal_shell/action_sheet_ios.clj
+++ b/src/natal_shell/action_sheet_ios.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.showActionSheetWithOptions)
-   (clojure.core/list 'js/React.ActionSheetIOS)
+   (clojure.core/list 'js/ReactNative.ActionSheetIOS)
    args)))
 (clojure.core/defmacro
  show-share-action-sheet-with-options
@@ -15,5 +15,5 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.showShareActionSheetWithOptions)
-   (clojure.core/list 'js/React.ActionSheetIOS)
+   (clojure.core/list 'js/ReactNative.ActionSheetIOS)
    args)))

--- a/src/natal_shell/alert.clj
+++ b/src/natal_shell/alert.clj
@@ -7,5 +7,5 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.alert)
-   (clojure.core/list 'js/React.Alert)
+   (clojure.core/list 'js/ReactNative.Alert)
    args)))

--- a/src/natal_shell/alert_ios.clj
+++ b/src/natal_shell/alert_ios.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.alert)
-   (clojure.core/list 'js/React.AlertIOS)
+   (clojure.core/list 'js/ReactNative.AlertIOS)
    args)))
 (clojure.core/defmacro
  prompt
@@ -15,5 +15,5 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.prompt)
-   (clojure.core/list 'js/React.AlertIOS)
+   (clojure.core/list 'js/ReactNative.AlertIOS)
    args)))

--- a/src/natal_shell/animated.clj
+++ b/src/natal_shell/animated.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.decay)
-   (clojure.core/list 'js/React.Animated)
+   (clojure.core/list 'js/ReactNative.Animated)
    args)))
 (clojure.core/defmacro
  timing
@@ -15,7 +15,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.timing)
-   (clojure.core/list 'js/React.Animated)
+   (clojure.core/list 'js/ReactNative.Animated)
    args)))
 (clojure.core/defmacro
  spring
@@ -23,7 +23,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.spring)
-   (clojure.core/list 'js/React.Animated)
+   (clojure.core/list 'js/ReactNative.Animated)
    args)))
 (clojure.core/defmacro
  add
@@ -31,7 +31,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.add)
-   (clojure.core/list 'js/React.Animated)
+   (clojure.core/list 'js/ReactNative.Animated)
    args)))
 (clojure.core/defmacro
  multiply
@@ -39,7 +39,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.multiply)
-   (clojure.core/list 'js/React.Animated)
+   (clojure.core/list 'js/ReactNative.Animated)
    args)))
 (clojure.core/defmacro
  modulo
@@ -47,7 +47,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.modulo)
-   (clojure.core/list 'js/React.Animated)
+   (clojure.core/list 'js/ReactNative.Animated)
    args)))
 (clojure.core/defmacro
  delay
@@ -55,7 +55,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.delay)
-   (clojure.core/list 'js/React.Animated)
+   (clojure.core/list 'js/ReactNative.Animated)
    args)))
 (clojure.core/defmacro
  sequence
@@ -63,7 +63,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.sequence)
-   (clojure.core/list 'js/React.Animated)
+   (clojure.core/list 'js/ReactNative.Animated)
    args)))
 (clojure.core/defmacro
  parallel
@@ -71,7 +71,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.parallel)
-   (clojure.core/list 'js/React.Animated)
+   (clojure.core/list 'js/ReactNative.Animated)
    args)))
 (clojure.core/defmacro
  stagger
@@ -79,7 +79,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.stagger)
-   (clojure.core/list 'js/React.Animated)
+   (clojure.core/list 'js/ReactNative.Animated)
    args)))
 (clojure.core/defmacro
  event
@@ -87,7 +87,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.event)
-   (clojure.core/list 'js/React.Animated)
+   (clojure.core/list 'js/ReactNative.Animated)
    args)))
 (clojure.core/defmacro
  create-animated-component
@@ -95,19 +95,19 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.createAnimatedComponent)
-   (clojure.core/list 'js/React.Animated)
+   (clojure.core/list 'js/ReactNative.Animated)
    args)))
 (clojure.core/defmacro
  value
  [& args]
  (clojure.core/seq
   (clojure.core/concat
-   (clojure.core/list 'js/React.Animated.Value.)
+   (clojure.core/list 'js/ReactNative.Animated.Value.)
    args)))
 (clojure.core/defmacro
  value-xy
  [& args]
  (clojure.core/seq
   (clojure.core/concat
-   (clojure.core/list 'js/React.Animated.ValueXY.)
+   (clojure.core/list 'js/ReactNative.Animated.ValueXY.)
    args)))

--- a/src/natal_shell/app_registry.clj
+++ b/src/natal_shell/app_registry.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.registerConfig)
-   (clojure.core/list 'js/React.AppRegistry)
+   (clojure.core/list 'js/ReactNative.AppRegistry)
    args)))
 (clojure.core/defmacro
  register-component
@@ -15,7 +15,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.registerComponent)
-   (clojure.core/list 'js/React.AppRegistry)
+   (clojure.core/list 'js/ReactNative.AppRegistry)
    args)))
 (clojure.core/defmacro
  register-runnable
@@ -23,7 +23,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.registerRunnable)
-   (clojure.core/list 'js/React.AppRegistry)
+   (clojure.core/list 'js/ReactNative.AppRegistry)
    args)))
 (clojure.core/defmacro
  get-app-keys
@@ -31,7 +31,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.getAppKeys)
-   (clojure.core/list 'js/React.AppRegistry)
+   (clojure.core/list 'js/ReactNative.AppRegistry)
    args)))
 (clojure.core/defmacro
  run-application
@@ -39,7 +39,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.runApplication)
-   (clojure.core/list 'js/React.AppRegistry)
+   (clojure.core/list 'js/ReactNative.AppRegistry)
    args)))
 (clojure.core/defmacro
  unmount-application-component-at-root-tag
@@ -47,5 +47,5 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.unmountApplicationComponentAtRootTag)
-   (clojure.core/list 'js/React.AppRegistry)
+   (clojure.core/list 'js/ReactNative.AppRegistry)
    args)))

--- a/src/natal_shell/app_state.clj
+++ b/src/natal_shell/app_state.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.addEventListener)
-   (clojure.core/list 'js/React.AppState)
+   (clojure.core/list 'js/ReactNative.AppState)
    args)))
 (clojure.core/defmacro
  remove-event-listener
@@ -15,7 +15,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.removeEventListener)
-   (clojure.core/list 'js/React.AppState)
+   (clojure.core/list 'js/ReactNative.AppState)
    args)))
 (clojure.core/defmacro
  current-state
@@ -23,4 +23,4 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.-currentState)
-   (clojure.core/list 'js/React.AppState))))
+   (clojure.core/list 'js/ReactNative.AppState))))

--- a/src/natal_shell/app_state_ios.clj
+++ b/src/natal_shell/app_state_ios.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.addEventListener)
-   (clojure.core/list 'js/React.AppStateIOS)
+   (clojure.core/list 'js/ReactNative.AppStateIOS)
    args)))
 (clojure.core/defmacro
  remove-event-listener
@@ -15,7 +15,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.removeEventListener)
-   (clojure.core/list 'js/React.AppStateIOS)
+   (clojure.core/list 'js/ReactNative.AppStateIOS)
    args)))
 (clojure.core/defmacro
  current-state
@@ -23,4 +23,4 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.-currentState)
-   (clojure.core/list 'js/React.AppStateIOS))))
+   (clojure.core/list 'js/ReactNative.AppStateIOS))))

--- a/src/natal_shell/async_storage.clj
+++ b/src/natal_shell/async_storage.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.getItem)
-   (clojure.core/list 'js/React.AsyncStorage)
+   (clojure.core/list 'js/ReactNative.AsyncStorage)
    args)))
 (clojure.core/defmacro
  set-item
@@ -15,7 +15,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.setItem)
-   (clojure.core/list 'js/React.AsyncStorage)
+   (clojure.core/list 'js/ReactNative.AsyncStorage)
    args)))
 (clojure.core/defmacro
  remove-item
@@ -23,7 +23,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.removeItem)
-   (clojure.core/list 'js/React.AsyncStorage)
+   (clojure.core/list 'js/ReactNative.AsyncStorage)
    args)))
 (clojure.core/defmacro
  merge-item
@@ -31,7 +31,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.mergeItem)
-   (clojure.core/list 'js/React.AsyncStorage)
+   (clojure.core/list 'js/ReactNative.AsyncStorage)
    args)))
 (clojure.core/defmacro
  clear
@@ -39,7 +39,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.clear)
-   (clojure.core/list 'js/React.AsyncStorage)
+   (clojure.core/list 'js/ReactNative.AsyncStorage)
    args)))
 (clojure.core/defmacro
  get-all-keys
@@ -47,7 +47,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.getAllKeys)
-   (clojure.core/list 'js/React.AsyncStorage)
+   (clojure.core/list 'js/ReactNative.AsyncStorage)
    args)))
 (clojure.core/defmacro
  flush-get-requests
@@ -55,7 +55,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.flushGetRequests)
-   (clojure.core/list 'js/React.AsyncStorage)
+   (clojure.core/list 'js/ReactNative.AsyncStorage)
    args)))
 (clojure.core/defmacro
  multi-get
@@ -63,7 +63,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.multiGet)
-   (clojure.core/list 'js/React.AsyncStorage)
+   (clojure.core/list 'js/ReactNative.AsyncStorage)
    args)))
 (clojure.core/defmacro
  multi-set
@@ -71,7 +71,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.multiSet)
-   (clojure.core/list 'js/React.AsyncStorage)
+   (clojure.core/list 'js/ReactNative.AsyncStorage)
    args)))
 (clojure.core/defmacro
  multi-remove
@@ -79,7 +79,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.multiRemove)
-   (clojure.core/list 'js/React.AsyncStorage)
+   (clojure.core/list 'js/ReactNative.AsyncStorage)
    args)))
 (clojure.core/defmacro
  multi-merge
@@ -87,5 +87,5 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.multiMerge)
-   (clojure.core/list 'js/React.AsyncStorage)
+   (clojure.core/list 'js/ReactNative.AsyncStorage)
    args)))

--- a/src/natal_shell/back_android.clj
+++ b/src/natal_shell/back_android.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.exitApp)
-   (clojure.core/list 'js/React.BackAndroid)
+   (clojure.core/list 'js/ReactNative.BackAndroid)
    args)))
 (clojure.core/defmacro
  add-event-listener
@@ -15,7 +15,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.addEventListener)
-   (clojure.core/list 'js/React.BackAndroid)
+   (clojure.core/list 'js/ReactNative.BackAndroid)
    args)))
 (clojure.core/defmacro
  remove-event-listener
@@ -23,5 +23,5 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.removeEventListener)
-   (clojure.core/list 'js/React.BackAndroid)
+   (clojure.core/list 'js/ReactNative.BackAndroid)
    args)))

--- a/src/natal_shell/camera_roll.clj
+++ b/src/natal_shell/camera_roll.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.saveImageWithTag)
-   (clojure.core/list 'js/React.CameraRoll)
+   (clojure.core/list 'js/ReactNative.CameraRoll)
    args)))
 (clojure.core/defmacro
  get-photos
@@ -15,5 +15,5 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.getPhotos)
-   (clojure.core/list 'js/React.CameraRoll)
+   (clojure.core/list 'js/ReactNative.CameraRoll)
    args)))

--- a/src/natal_shell/clipboard.clj
+++ b/src/natal_shell/clipboard.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.getString)
-   (clojure.core/list 'js/React.Clipboard)
+   (clojure.core/list 'js/ReactNative.Clipboard)
    args)))
 (clojure.core/defmacro
  set-string
@@ -15,5 +15,5 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.setString)
-   (clojure.core/list 'js/React.Clipboard)
+   (clojure.core/list 'js/ReactNative.Clipboard)
    args)))

--- a/src/natal_shell/components.clj
+++ b/src/natal_shell/components.clj
@@ -7,14 +7,14 @@
 (defn wrap-component [js-name]
   `(defmacro ~(symbol (to-kebab js-name)) [props# & children#]
     `(js/React.createElement
-      ~'~(symbol (str "js/React." js-name))
+      ~'~(symbol (str "js/ReactNative." js-name))
       (cljs.core/clj->js ~props#)
       ~@children#)))
 
 
 (defn wrap-reagent [js-name]
   `(def ~(symbol (to-kebab js-name))
-    (r/adapt-react-class (~(symbol (str ".-" js-name)) ~'js/React))))
+    (r/adapt-react-class (~(symbol (str ".-" js-name)) ~'js/ReactNative.))))
 
 
 (defmacro wrap-all []

--- a/src/natal_shell/components.clj
+++ b/src/natal_shell/components.clj
@@ -14,7 +14,7 @@
 
 (defn wrap-reagent [js-name]
   `(def ~(symbol (to-kebab js-name))
-    (r/adapt-react-class (~(symbol (str ".-" js-name)) ~'js/ReactNative.))))
+    (r/adapt-react-class (~(symbol (str ".-" js-name)) ~'js/ReactNative))))
 
 
 (defmacro wrap-all []

--- a/src/natal_shell/data_source.clj
+++ b/src/natal_shell/data_source.clj
@@ -1,7 +1,7 @@
 (ns natal-shell.data-source)
 
 (defmacro data-source [config]
-  `(js/React.ListView.DataSource. (cljs.core/clj->js ~config)))
+  `(js/ReactNative.ListView.DataSource. (cljs.core/clj->js ~config)))
 
 (defmacro clone-with-rows [ds rows]
   `(.cloneWithRows ~ds (cljs.core/clj->js ~rows)))

--- a/src/natal_shell/date_picker_android.clj
+++ b/src/natal_shell/date_picker_android.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.open)
-   (clojure.core/list 'js/React.DatePickerAndroid)
+   (clojure.core/list 'js/ReactNative.DatePickerAndroid)
    args)))
 (clojure.core/defmacro
  date-set-action
@@ -15,7 +15,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.dateSetAction)
-   (clojure.core/list 'js/React.DatePickerAndroid)
+   (clojure.core/list 'js/ReactNative.DatePickerAndroid)
    args)))
 (clojure.core/defmacro
  dismissed-action
@@ -23,5 +23,5 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.dismissedAction)
-   (clojure.core/list 'js/React.DatePickerAndroid)
+   (clojure.core/list 'js/ReactNative.DatePickerAndroid)
    args)))

--- a/src/natal_shell/dimensions.clj
+++ b/src/natal_shell/dimensions.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.set)
-   (clojure.core/list 'js/React.Dimensions)
+   (clojure.core/list 'js/ReactNative.Dimensions)
    args)))
 (clojure.core/defmacro
  get
@@ -15,5 +15,5 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.get)
-   (clojure.core/list 'js/React.Dimensions)
+   (clojure.core/list 'js/ReactNative.Dimensions)
    args)))

--- a/src/natal_shell/intent_android.clj
+++ b/src/natal_shell/intent_android.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.openURL)
-   (clojure.core/list 'js/React.IntentAndroid)
+   (clojure.core/list 'js/ReactNative.IntentAndroid)
    args)))
 (clojure.core/defmacro
  can-open-url
@@ -15,7 +15,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.canOpenURL)
-   (clojure.core/list 'js/React.IntentAndroid)
+   (clojure.core/list 'js/ReactNative.IntentAndroid)
    args)))
 (clojure.core/defmacro
  get-initial-url
@@ -23,5 +23,5 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.getInitialURL)
-   (clojure.core/list 'js/React.IntentAndroid)
+   (clojure.core/list 'js/ReactNative.IntentAndroid)
    args)))

--- a/src/natal_shell/interaction_manager.clj
+++ b/src/natal_shell/interaction_manager.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.runAfterInteractions)
-   (clojure.core/list 'js/React.InteractionManager)
+   (clojure.core/list 'js/ReactNative.InteractionManager)
    args)))
 (clojure.core/defmacro
  create-interaction-handle
@@ -15,7 +15,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.createInteractionHandle)
-   (clojure.core/list 'js/React.InteractionManager)
+   (clojure.core/list 'js/ReactNative.InteractionManager)
    args)))
 (clojure.core/defmacro
  clear-interaction-handle
@@ -23,7 +23,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.clearInteractionHandle)
-   (clojure.core/list 'js/React.InteractionManager)
+   (clojure.core/list 'js/ReactNative.InteractionManager)
    args)))
 (clojure.core/defmacro
  set-deadline
@@ -31,7 +31,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.setDeadline)
-   (clojure.core/list 'js/React.InteractionManager)
+   (clojure.core/list 'js/ReactNative.InteractionManager)
    args)))
 (clojure.core/defmacro
  events
@@ -39,11 +39,11 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.-Events)
-   (clojure.core/list 'js/React.InteractionManager))))
+   (clojure.core/list 'js/ReactNative.InteractionManager))))
 (clojure.core/defmacro
  add-listener
  []
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.-addListener)
-   (clojure.core/list 'js/React.InteractionManager))))
+   (clojure.core/list 'js/ReactNative.InteractionManager))))

--- a/src/natal_shell/layout_animation.clj
+++ b/src/natal_shell/layout_animation.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.configureNext)
-   (clojure.core/list 'js/React.LayoutAnimation)
+   (clojure.core/list 'js/ReactNative.LayoutAnimation)
    args)))
 (clojure.core/defmacro
  create
@@ -15,7 +15,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.create)
-   (clojure.core/list 'js/React.LayoutAnimation)
+   (clojure.core/list 'js/ReactNative.LayoutAnimation)
    args)))
 (clojure.core/defmacro
  types
@@ -23,46 +23,46 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.-Types)
-   (clojure.core/list 'js/React.LayoutAnimation))))
+   (clojure.core/list 'js/ReactNative.LayoutAnimation))))
 (clojure.core/defmacro
  properties
  []
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.-Properties)
-   (clojure.core/list 'js/React.LayoutAnimation))))
+   (clojure.core/list 'js/ReactNative.LayoutAnimation))))
 (clojure.core/defmacro
  config-checker
  []
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.-configChecker)
-   (clojure.core/list 'js/React.LayoutAnimation))))
+   (clojure.core/list 'js/ReactNative.LayoutAnimation))))
 (clojure.core/defmacro
  presets
  []
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.-Presets)
-   (clojure.core/list 'js/React.LayoutAnimation))))
+   (clojure.core/list 'js/ReactNative.LayoutAnimation))))
 (clojure.core/defmacro
  ease-in-ease-out
  []
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.-easeInEaseOut)
-   (clojure.core/list 'js/React.LayoutAnimation))))
+   (clojure.core/list 'js/ReactNative.LayoutAnimation))))
 (clojure.core/defmacro
  linear
  []
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.-linear)
-   (clojure.core/list 'js/React.LayoutAnimation))))
+   (clojure.core/list 'js/ReactNative.LayoutAnimation))))
 (clojure.core/defmacro
  spring
  []
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.-spring)
-   (clojure.core/list 'js/React.LayoutAnimation))))
+   (clojure.core/list 'js/ReactNative.LayoutAnimation))))

--- a/src/natal_shell/linking.clj
+++ b/src/natal_shell/linking.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.addEventListener)
-   (clojure.core/list 'js/React.Linking)
+   (clojure.core/list 'js/ReactNative.Linking)
    args)))
 (clojure.core/defmacro
  remove-event-listener
@@ -15,7 +15,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.removeEventListener)
-   (clojure.core/list 'js/React.Linking)
+   (clojure.core/list 'js/ReactNative.Linking)
    args)))
 (clojure.core/defmacro
  open-url
@@ -23,7 +23,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.openURL)
-   (clojure.core/list 'js/React.Linking)
+   (clojure.core/list 'js/ReactNative.Linking)
    args)))
 (clojure.core/defmacro
  can-open-url
@@ -31,7 +31,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.canOpenURL)
-   (clojure.core/list 'js/React.Linking)
+   (clojure.core/list 'js/ReactNative.Linking)
    args)))
 (clojure.core/defmacro
  get-initial-url
@@ -39,5 +39,5 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.getInitialURL)
-   (clojure.core/list 'js/React.Linking)
+   (clojure.core/list 'js/ReactNative.Linking)
    args)))

--- a/src/natal_shell/linking_ios.clj
+++ b/src/natal_shell/linking_ios.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.addEventListener)
-   (clojure.core/list 'js/React.LinkingIOS)
+   (clojure.core/list 'js/ReactNative.LinkingIOS)
    args)))
 (clojure.core/defmacro
  remove-event-listener
@@ -15,7 +15,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.removeEventListener)
-   (clojure.core/list 'js/React.LinkingIOS)
+   (clojure.core/list 'js/ReactNative.LinkingIOS)
    args)))
 (clojure.core/defmacro
  open-url
@@ -23,7 +23,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.openURL)
-   (clojure.core/list 'js/React.LinkingIOS)
+   (clojure.core/list 'js/ReactNative.LinkingIOS)
    args)))
 (clojure.core/defmacro
  can-open-url
@@ -31,7 +31,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.canOpenURL)
-   (clojure.core/list 'js/React.LinkingIOS)
+   (clojure.core/list 'js/ReactNative.LinkingIOS)
    args)))
 (clojure.core/defmacro
  pop-initial-url
@@ -39,5 +39,5 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.popInitialURL)
-   (clojure.core/list 'js/React.LinkingIOS)
+   (clojure.core/list 'js/ReactNative.LinkingIOS)
    args)))

--- a/src/natal_shell/native_methods_mixin.clj
+++ b/src/natal_shell/native_methods_mixin.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.measure)
-   (clojure.core/list 'js/React.NativeMethodsMixin)
+   (clojure.core/list 'js/ReactNative.NativeMethodsMixin)
    args)))
 (clojure.core/defmacro
  measure-in-window
@@ -15,7 +15,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.measureInWindow)
-   (clojure.core/list 'js/React.NativeMethodsMixin)
+   (clojure.core/list 'js/ReactNative.NativeMethodsMixin)
    args)))
 (clojure.core/defmacro
  measure-layout
@@ -23,15 +23,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.measureLayout)
-   (clojure.core/list 'js/React.NativeMethodsMixin)
-   args)))
-(clojure.core/defmacro
- set-native-props
- [& args]
- (clojure.core/seq
-  (clojure.core/concat
-   (clojure.core/list '.setNativeProps)
-   (clojure.core/list 'js/React.NativeMethodsMixin)
+   (clojure.core/list 'js/ReactNative.NativeMethodsMixin)
    args)))
 (clojure.core/defmacro
  focus
@@ -39,7 +31,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.focus)
-   (clojure.core/list 'js/React.NativeMethodsMixin)
+   (clojure.core/list 'js/ReactNative.NativeMethodsMixin)
    args)))
 (clojure.core/defmacro
  blur
@@ -47,5 +39,5 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.blur)
-   (clojure.core/list 'js/React.NativeMethodsMixin)
+   (clojure.core/list 'js/ReactNative.NativeMethodsMixin)
    args)))

--- a/src/natal_shell/net_info.clj
+++ b/src/natal_shell/net_info.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.addEventListener)
-   (clojure.core/list 'js/React.NetInfo)
+   (clojure.core/list 'js/ReactNative.NetInfo)
    args)))
 (clojure.core/defmacro
  remove-event-listener
@@ -15,7 +15,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.removeEventListener)
-   (clojure.core/list 'js/React.NetInfo)
+   (clojure.core/list 'js/ReactNative.NetInfo)
    args)))
 (clojure.core/defmacro
  fetch
@@ -23,7 +23,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.fetch)
-   (clojure.core/list 'js/React.NetInfo)
+   (clojure.core/list 'js/ReactNative.NetInfo)
    args)))
 (clojure.core/defmacro
  is-connection-expensive
@@ -31,7 +31,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.isConnectionExpensive)
-   (clojure.core/list 'js/React.NetInfo)
+   (clojure.core/list 'js/ReactNative.NetInfo)
    args)))
 (clojure.core/defmacro
  is-connected
@@ -39,4 +39,4 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.-isConnected)
-   (clojure.core/list 'js/React.NetInfo))))
+   (clojure.core/list 'js/ReactNative.NetInfo))))

--- a/src/natal_shell/pan_responder.clj
+++ b/src/natal_shell/pan_responder.clj
@@ -7,5 +7,5 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.create)
-   (clojure.core/list 'js/React.PanResponder)
+   (clojure.core/list 'js/ReactNative.PanResponder)
    args)))

--- a/src/natal_shell/pixel_ratio.clj
+++ b/src/natal_shell/pixel_ratio.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.get)
-   (clojure.core/list 'js/React.PixelRatio)
+   (clojure.core/list 'js/ReactNative.PixelRatio)
    args)))
 (clojure.core/defmacro
  get-font-scale
@@ -15,7 +15,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.getFontScale)
-   (clojure.core/list 'js/React.PixelRatio)
+   (clojure.core/list 'js/ReactNative.PixelRatio)
    args)))
 (clojure.core/defmacro
  get-pixel-size-for-layout-size
@@ -23,7 +23,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.getPixelSizeForLayoutSize)
-   (clojure.core/list 'js/React.PixelRatio)
+   (clojure.core/list 'js/ReactNative.PixelRatio)
    args)))
 (clojure.core/defmacro
  round-to-nearest-pixel
@@ -31,7 +31,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.roundToNearestPixel)
-   (clojure.core/list 'js/React.PixelRatio)
+   (clojure.core/list 'js/ReactNative.PixelRatio)
    args)))
 (clojure.core/defmacro
  start-detecting
@@ -39,5 +39,5 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.startDetecting)
-   (clojure.core/list 'js/React.PixelRatio)
+   (clojure.core/list 'js/ReactNative.PixelRatio)
    args)))

--- a/src/natal_shell/push_notification_ios.clj
+++ b/src/natal_shell/push_notification_ios.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.presentLocalNotification)
-   (clojure.core/list 'js/React.PushNotificationIOS)
+   (clojure.core/list 'js/ReactNative.PushNotificationIOS)
    args)))
 (clojure.core/defmacro
  schedule-local-notification
@@ -15,7 +15,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.scheduleLocalNotification)
-   (clojure.core/list 'js/React.PushNotificationIOS)
+   (clojure.core/list 'js/ReactNative.PushNotificationIOS)
    args)))
 (clojure.core/defmacro
  cancel-all-local-notifications
@@ -23,7 +23,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.cancelAllLocalNotifications)
-   (clojure.core/list 'js/React.PushNotificationIOS)
+   (clojure.core/list 'js/ReactNative.PushNotificationIOS)
    args)))
 (clojure.core/defmacro
  set-application-icon-badge-number
@@ -31,7 +31,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.setApplicationIconBadgeNumber)
-   (clojure.core/list 'js/React.PushNotificationIOS)
+   (clojure.core/list 'js/ReactNative.PushNotificationIOS)
    args)))
 (clojure.core/defmacro
  get-application-icon-badge-number
@@ -39,7 +39,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.getApplicationIconBadgeNumber)
-   (clojure.core/list 'js/React.PushNotificationIOS)
+   (clojure.core/list 'js/ReactNative.PushNotificationIOS)
    args)))
 (clojure.core/defmacro
  cancel-local-notifications
@@ -47,7 +47,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.cancelLocalNotifications)
-   (clojure.core/list 'js/React.PushNotificationIOS)
+   (clojure.core/list 'js/ReactNative.PushNotificationIOS)
    args)))
 (clojure.core/defmacro
  add-event-listener
@@ -55,7 +55,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.addEventListener)
-   (clojure.core/list 'js/React.PushNotificationIOS)
+   (clojure.core/list 'js/ReactNative.PushNotificationIOS)
    args)))
 (clojure.core/defmacro
  request-permissions
@@ -63,7 +63,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.requestPermissions)
-   (clojure.core/list 'js/React.PushNotificationIOS)
+   (clojure.core/list 'js/ReactNative.PushNotificationIOS)
    args)))
 (clojure.core/defmacro
  abandon-permissions
@@ -71,7 +71,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.abandonPermissions)
-   (clojure.core/list 'js/React.PushNotificationIOS)
+   (clojure.core/list 'js/ReactNative.PushNotificationIOS)
    args)))
 (clojure.core/defmacro
  check-permissions
@@ -79,7 +79,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.checkPermissions)
-   (clojure.core/list 'js/React.PushNotificationIOS)
+   (clojure.core/list 'js/ReactNative.PushNotificationIOS)
    args)))
 (clojure.core/defmacro
  remove-event-listener
@@ -87,7 +87,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.removeEventListener)
-   (clojure.core/list 'js/React.PushNotificationIOS)
+   (clojure.core/list 'js/ReactNative.PushNotificationIOS)
    args)))
 (clojure.core/defmacro
  pop-initial-notification
@@ -95,7 +95,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.popInitialNotification)
-   (clojure.core/list 'js/React.PushNotificationIOS)
+   (clojure.core/list 'js/ReactNative.PushNotificationIOS)
    args)))
 (clojure.core/defmacro
  constructor
@@ -103,7 +103,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.constructor)
-   (clojure.core/list 'js/React.PushNotificationIOS)
+   (clojure.core/list 'js/ReactNative.PushNotificationIOS)
    args)))
 (clojure.core/defmacro
  get-message
@@ -111,7 +111,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.getMessage)
-   (clojure.core/list 'js/React.PushNotificationIOS)
+   (clojure.core/list 'js/ReactNative.PushNotificationIOS)
    args)))
 (clojure.core/defmacro
  get-sound
@@ -119,7 +119,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.getSound)
-   (clojure.core/list 'js/React.PushNotificationIOS)
+   (clojure.core/list 'js/ReactNative.PushNotificationIOS)
    args)))
 (clojure.core/defmacro
  get-alert
@@ -127,7 +127,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.getAlert)
-   (clojure.core/list 'js/React.PushNotificationIOS)
+   (clojure.core/list 'js/ReactNative.PushNotificationIOS)
    args)))
 (clojure.core/defmacro
  get-badge-count
@@ -135,7 +135,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.getBadgeCount)
-   (clojure.core/list 'js/React.PushNotificationIOS)
+   (clojure.core/list 'js/ReactNative.PushNotificationIOS)
    args)))
 (clojure.core/defmacro
  get-data
@@ -143,5 +143,5 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.getData)
-   (clojure.core/list 'js/React.PushNotificationIOS)
+   (clojure.core/list 'js/ReactNative.PushNotificationIOS)
    args)))

--- a/src/natal_shell/status_bar_ios.clj
+++ b/src/natal_shell/status_bar_ios.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.setStyle)
-   (clojure.core/list 'js/React.StatusBarIOS)
+   (clojure.core/list 'js/ReactNative.StatusBarIOS)
    args)))
 (clojure.core/defmacro
  set-hidden
@@ -15,7 +15,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.setHidden)
-   (clojure.core/list 'js/React.StatusBarIOS)
+   (clojure.core/list 'js/ReactNative.StatusBarIOS)
    args)))
 (clojure.core/defmacro
  set-network-activity-indicator-visible
@@ -23,5 +23,5 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.setNetworkActivityIndicatorVisible)
-   (clojure.core/list 'js/React.StatusBarIOS)
+   (clojure.core/list 'js/ReactNative.StatusBarIOS)
    args)))

--- a/src/natal_shell/style_sheet.clj
+++ b/src/natal_shell/style_sheet.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.create)
-   (clojure.core/list 'js/React.StyleSheet)
+   (clojure.core/list 'js/ReactNative.StyleSheet)
    args)))
 (clojure.core/defmacro
  hairline-width
@@ -15,11 +15,11 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.-hairlineWidth)
-   (clojure.core/list 'js/React.StyleSheet))))
+   (clojure.core/list 'js/ReactNative.StyleSheet))))
 (clojure.core/defmacro
  flatten
  []
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.-flatten)
-   (clojure.core/list 'js/React.StyleSheet))))
+   (clojure.core/list 'js/ReactNative.StyleSheet))))

--- a/src/natal_shell/time_picker_android.clj
+++ b/src/natal_shell/time_picker_android.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.open)
-   (clojure.core/list 'js/React.TimePickerAndroid)
+   (clojure.core/list 'js/ReactNative.TimePickerAndroid)
    args)))
 (clojure.core/defmacro
  time-set-action
@@ -15,7 +15,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.timeSetAction)
-   (clojure.core/list 'js/React.TimePickerAndroid)
+   (clojure.core/list 'js/ReactNative.TimePickerAndroid)
    args)))
 (clojure.core/defmacro
  dismissed-action
@@ -23,5 +23,5 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.dismissedAction)
-   (clojure.core/list 'js/React.TimePickerAndroid)
+   (clojure.core/list 'js/ReactNative.TimePickerAndroid)
    args)))

--- a/src/natal_shell/toast_android.clj
+++ b/src/natal_shell/toast_android.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.show)
-   (clojure.core/list 'js/React.ToastAndroid)
+   (clojure.core/list 'js/ReactNative.ToastAndroid)
    args)))
 (clojure.core/defmacro
  short
@@ -15,11 +15,11 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.-SHORT)
-   (clojure.core/list 'js/React.ToastAndroid))))
+   (clojure.core/list 'js/ReactNative.ToastAndroid))))
 (clojure.core/defmacro
  long
  []
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.-LONG)
-   (clojure.core/list 'js/React.ToastAndroid))))
+   (clojure.core/list 'js/ReactNative.ToastAndroid))))

--- a/src/natal_shell/vibration.clj
+++ b/src/natal_shell/vibration.clj
@@ -7,7 +7,7 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.vibrate)
-   (clojure.core/list 'js/React.Vibration)
+   (clojure.core/list 'js/ReactNative.Vibration)
    args)))
 (clojure.core/defmacro
  cancel
@@ -15,5 +15,5 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.cancel)
-   (clojure.core/list 'js/React.Vibration)
+   (clojure.core/list 'js/ReactNative.Vibration)
    args)))

--- a/src/natal_shell/vibration_ios.clj
+++ b/src/natal_shell/vibration_ios.clj
@@ -7,5 +7,5 @@
  (clojure.core/seq
   (clojure.core/concat
    (clojure.core/list '.vibrate)
-   (clojure.core/list 'js/React.VibrationIOS)
+   (clojure.core/list 'js/ReactNative.VibrationIOS)
    args)))


### PR DESCRIPTION
This PR will make natal-shell version 0.3.0 work with ReactNative 0.25+
- updated scraper to generate RN api using js/ReactNative variable
- re-run the scraper
- bumped project version to  0.3.0-SNAPSHOT
