### PR TITLE
Replace clj->js with to-array in clone-with-rows

### DIFF
--- a/src/natal_shell/data_source.clj
+++ b/src/natal_shell/data_source.clj
@@ -4,4 +4,4 @@
   `(js/ReactNative.ListView.DataSource. (cljs.core/clj->js ~config)))
 
 (defmacro clone-with-rows [ds rows]
-  `(.cloneWithRows ~ds (cljs.core/clj->js ~rows)))
+  `(.cloneWithRows ~ds (to-array ~rows)))


### PR DESCRIPTION
.cloneWithRows and ListView only needs a javascript array, and treats everything else inside as a blob of data. This allows namespaced keywords to be retained, which is important for frontend libraries like om.next
